### PR TITLE
Define `KERNEL_DIR` once and use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 obj-m := system76.o
-KVERSION := $(shell uname -r)
+KERNEL_DIR = /lib/modules/$(shell uname -r)/build
 
 all:
-	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
+	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" modules
 
 clean:
-	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) clean
+	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" clean


### PR DESCRIPTION
Having the `KERNEL_DIR` make it possible  to "override" it via
CLI (it'll help to build this module for Gentoo using "standard"
`linux-mod.eclass`).

Also, enclose `$(PWD)` into quotes because it may have spaces
(being cloned into developer's machine).