### PR TITLE
Reduce logging by identifying debug log messages correctly

### DIFF
--- a/system76.c
+++ b/system76.c
@@ -103,13 +103,13 @@ static void s76_wmi_notify(u32 value, void *context) {
 	u32 event;
 
 	if (value != 0xD0) {
-		S76_INFO("Unexpected WMI event (%0#6x)\n", value);
+		S76_DEBUG("Unexpected WMI event (%0#6x)\n", value);
 		return;
 	}
 
 	s76_wmbb(GET_EVENT, 0, &event);
 
-	S76_INFO("WMI event code (%x)\n", event);
+	S76_DEBUG("WMI event code (%x)\n", event);
 
 	switch (event) {
 	case 0x81:
@@ -140,7 +140,7 @@ static void s76_wmi_notify(u32 value, void *context) {
 		s76_input_touchpad_wmi(true);
 		break;
 	default:
-		S76_INFO("Unknown WMI event code (%x)\n", event);
+		S76_DEBUG("Unknown WMI event code (%x)\n", event);
 		break;
 	}
 }
@@ -204,7 +204,7 @@ static int s76_remove(struct platform_device *dev) {
 }
 
 static int s76_suspend(struct platform_device *dev, pm_message_t status) {
-	S76_INFO("s76_suspend\n");
+	S76_DEBUG("s76_suspend\n");
 
 	kb_led_suspend();
 
@@ -212,7 +212,7 @@ static int s76_suspend(struct platform_device *dev, pm_message_t status) {
 }
 
 static int s76_resume(struct platform_device *dev) {
-	S76_INFO("s76_resume\n");
+	S76_DEBUG("s76_resume\n");
 
 	msleep(2000);
 

--- a/system76_input.c
+++ b/system76_input.c
@@ -58,7 +58,7 @@ MODULE_PARM_DESC(poll_freq, "Set polling frequency");
 static struct task_struct *s76_input_polling_task;
 
 static void s76_input_key(unsigned int code) {
-	S76_INFO("Send key %x\n", code);
+	S76_DEBUG("Send key %x\n", code);
 
 	mutex_lock(&s76_input_report_mutex);
 
@@ -72,7 +72,7 @@ static void s76_input_key(unsigned int code) {
 }
 
 static int s76_input_polling_thread(void *data) {
-	S76_INFO("Polling thread started (PID: %i), polling at %i Hz\n",
+	S76_DEBUG("Polling thread started (PID: %i), polling at %i Hz\n",
 				current->pid, param_poll_freq);
 
 	while (!kthread_should_stop()) {
@@ -82,7 +82,7 @@ static int s76_input_polling_thread(void *data) {
 		if (byte & 0x40) {
 			ec_write(0xDB, byte & ~0x40);
 
-			S76_INFO("Airplane-Mode Hotkey pressed (EC)\n");
+			S76_DEBUG("Airplane-Mode Hotkey pressed (EC)\n");
 
 			s76_input_key(AIRPLANE_KEY);
 		}
@@ -90,16 +90,16 @@ static int s76_input_polling_thread(void *data) {
 		msleep_interruptible(1000 / param_poll_freq);
 	}
 
-	S76_INFO("Polling thread exiting\n");
+	S76_DEBUG("Polling thread exiting\n");
 
 	return 0;
 }
 
 static void s76_input_airplane_wmi(void) {
-	S76_INFO("Airplane-Mode Hotkey pressed (WMI)\n");
+	S76_DEBUG("Airplane-Mode Hotkey pressed (WMI)\n");
 
 	if (s76_input_polling_task) {
-		S76_INFO("Stopping polling thread\n");
+		S76_DEBUG("Stopping polling thread\n");
 		kthread_stop(s76_input_polling_task);
 		s76_input_polling_task = NULL;
 	}
@@ -108,7 +108,7 @@ static void s76_input_airplane_wmi(void) {
 }
 
 static void s76_input_touchpad_wmi(bool enabled) {
-	S76_INFO("Touchpad Hotkey pressed (WMI) %d\n", enabled);
+	S76_DEBUG("Touchpad Hotkey pressed (WMI) %d\n", enabled);
 
 	if (enabled) {
 		s76_input_key(TOUCHPAD_ON_KEY);

--- a/system76_kb-led.c
+++ b/system76_kb-led.c
@@ -61,7 +61,7 @@ static enum led_brightness kb_led_get(struct led_classdev *led_cdev) {
 }
 
 static int kb_led_set(struct led_classdev *led_cdev, enum led_brightness value) {
-	S76_INFO("kb_led_set %d\n", (int)value);
+	S76_DEBUG("kb_led_set %d\n", (int)value);
 
 	if (!s76_wmbb(SET_KB_LED, 0xF4000000 | value, NULL)) {
 		kb_led_brightness = value;
@@ -73,7 +73,7 @@ static int kb_led_set(struct led_classdev *led_cdev, enum led_brightness value) 
 static void kb_led_color_set(enum kb_led_region region, union kb_led_color color) {
 	u32 cmd;
 
-	S76_INFO("kb_led_color_set %d %06X\n", (int)region, (int)color.rgb);
+	S76_DEBUG("kb_led_color_set %d %06X\n", (int)region, (int)color.rgb);
 
 	switch (region) {
 	case KB_LED_REGION_LEFT:
@@ -198,19 +198,19 @@ static struct device_attribute kb_led_color_extra_dev_attr = {
 };
 
 static void kb_led_enable(void) {
-	S76_INFO("kb_led_enable\n");
+	S76_DEBUG("kb_led_enable\n");
 
 	s76_wmbb(SET_KB_LED, 0xE007F001, NULL);
 }
 
 static void kb_led_disable(void) {
-	S76_INFO("kb_led_disable\n");
+	S76_DEBUG("kb_led_disable\n");
 
 	s76_wmbb(SET_KB_LED, 0xE0003001, NULL);
 }
 
 static void kb_led_suspend(void) {
-	S76_INFO("kb_led_suspend\n");
+	S76_DEBUG("kb_led_suspend\n");
 
 	// Disable keyboard backlight
 	kb_led_disable();
@@ -219,7 +219,7 @@ static void kb_led_suspend(void) {
 static void kb_led_resume(void) {
 	enum kb_led_region region;
 
-	S76_INFO("kb_led_resume\n");
+	S76_DEBUG("kb_led_resume\n");
 
 	// Disable keyboard backlight
 	kb_led_disable();
@@ -277,7 +277,7 @@ static void __exit kb_led_exit(void) {
 }
 
 static void kb_wmi_brightness(enum led_brightness value) {
-	S76_INFO("kb_wmi_brightness %d\n", (int)value);
+	S76_DEBUG("kb_wmi_brightness %d\n", (int)value);
 
 	kb_led_set(&kb_led, value);
 	led_classdev_notify_brightness_hw_changed(&kb_led, value);


### PR DESCRIPTION
This will make a number of log messages only present if debugging is enabled