### PR TITLE
Update the way touchpad and airplane mode is handled

### DIFF
--- a/debian/system76-dkms.install
+++ b/debian/system76-dkms.install
@@ -1,1 +1,2 @@
+lib/udev/hwdb.d
 usr/share/initramfs-tools

--- a/lib/udev/hwdb.d/99-system76-dkms.hwdb
+++ b/lib/udev/hwdb.d/99-system76-dkms.hwdb
@@ -1,0 +1,3 @@
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnSystem76*:pn*
+ KEYBOARD_KEY_f7=f21
+ KEYBOARD_KEY_f8=f21

--- a/system76.c
+++ b/system76.c
@@ -70,16 +70,22 @@ static struct s76_driver_data driver_data_white_kb = {
 	.kb_led = false,
 };
 
+static struct s76_driver_data driver_data_white_kb_hid = {
+	.ap_led = true,
+	.input = false,
+	.kb_led = false,
+};
+
 static struct s76_driver_data driver_data_color_kb = {
 	.ap_led = true,
 	.input = true,
 	.kb_led = true,
 };
 
-static struct s76_driver_data driver_data_white_kb_hid = {
+static struct s76_driver_data driver_data_color_kb_hid = {
 	.ap_led = true,
 	.input = false,
-	.kb_led = false,
+	.kb_led = true,
 };
 
 static struct s76_driver_data *driver_data = NULL;
@@ -336,7 +342,7 @@ static struct dmi_system_id s76_dmi_table[] __initdata = {
 	DMI_TABLE("oryp3-jeremy", color_kb),
 	DMI_TABLE("oryp4", color_kb),
 	DMI_TABLE("oryp4-b", color_kb),
-	DMI_TABLE("oryp5", color_kb),
+	DMI_TABLE("oryp5", color_kb_hid),
 	DMI_TABLE("serw11-b", color_kb),
 	{}
 };

--- a/system76.c
+++ b/system76.c
@@ -134,10 +134,10 @@ static void s76_wmi_notify(u32 value, void *context) {
 		s76_input_airplane_wmi();
 		break;
 	case 0xFC:
-		s76_input_touchpad_wmi(false);
+		// Touchpad WMI (disable)
 		break;
 	case 0xFD:
-		s76_input_touchpad_wmi(true);
+		// Touchpad WMI (enable)
 		break;
 	default:
 		S76_DEBUG("Unknown WMI event code (%x)\n", event);

--- a/system76_input.c
+++ b/system76_input.c
@@ -20,8 +20,6 @@
  */
 
 #define AIRPLANE_KEY KEY_WLAN
-#define TOUCHPAD_ON_KEY KEY_F21
-#define TOUCHPAD_OFF_KEY KEY_F21
 
 static struct input_dev *s76_input_device;
 static DEFINE_MUTEX(s76_input_report_mutex);
@@ -107,16 +105,6 @@ static void s76_input_airplane_wmi(void) {
 	s76_input_key(AIRPLANE_KEY);
 }
 
-static void s76_input_touchpad_wmi(bool enabled) {
-	S76_DEBUG("Touchpad Hotkey pressed (WMI) %d\n", enabled);
-
-	if (enabled) {
-		s76_input_key(TOUCHPAD_ON_KEY);
-	} else {
-		s76_input_key(TOUCHPAD_OFF_KEY);
-	}
-}
-
 static int s76_input_open(struct input_dev *dev) {
 	s76_input_polling_task = kthread_run(
 		s76_input_polling_thread,
@@ -156,8 +144,6 @@ static int __init s76_input_init(struct device *dev) {
 	s76_input_device->dev.parent = dev;
 	set_bit(EV_KEY, s76_input_device->evbit);
 	set_bit(AIRPLANE_KEY, s76_input_device->keybit);
-	set_bit(TOUCHPAD_ON_KEY, s76_input_device->keybit);
-	set_bit(TOUCHPAD_OFF_KEY, s76_input_device->keybit);
 
 	s76_input_device->open  = s76_input_open;
 	s76_input_device->close = s76_input_close;


### PR DESCRIPTION
With this change, it will use the native PS/2 events instead of WMI. A reboot is required after install to activate the new settings.