### PR TITLE
Fixed 'Section mismatch in reference' warnings in GCC 10

### DIFF
--- a/system76.c
+++ b/system76.c
@@ -170,7 +170,7 @@ static void s76_wmi_notify(u32 value, void *context) {
 	}
 }
 
-static int s76_probe(struct platform_device *dev) {
+static int __init s76_probe(struct platform_device *dev) {
 	int err;
 
 	if (driver_flags & DRIVER_AP_LED) {


### PR DESCRIPTION
If CONFIG_DEBUG_SECTION_MISMATCH option enabled in the kernel config and use GCC 10, the compiler produces 3 warnings:

```
WARNING: system76.o(.text.unlikely+0x2cb): Section mismatch in reference from the function s76_probe.cold() to the function .init.text:nv_hda_init.constprop.0()
The function s76_probe.cold() references the function __init nv_hda_init.constprop.0().
This is often because s76_probe.cold lacks a __init annotation or the annotation of nv_hda_init.constprop.0 is wrong.

WARNING: system76.o(.text.unlikely+0x348): Section mismatch in reference from the function s76_probe.cold() to the function .init.text:s76_input_init()
The function s76_probe.cold() references the function __init s76_input_init().
This is often because s76_probe.cold lacks a __init annotation or the annotation of s76_input_init is wrong.

WARNING: system76.o(.text.unlikely+0x36d): Section mismatch in reference from the function s76_probe.cold() to the function .init.text:kb_led_init()
The function s76_probe.cold() references the function __init kb_led_init().
This is often because s76_probe.cold lacks a __init annotation or the annotation of kb_led_init is wrong.
```
GCC versions prior 10 does not producing such warnings in these places.

So there we have two options here:
1. add __init annotation to s76_probe() function;
2. removed __init annotations form functions s76_input_init(), kb_led_init(), nv_hda_init().

I believe then authors placed __init annotation for s76_input_init(), kb_led_init(), nv_hda_init() correctly so I have to choose the first option and modify s76_probe().