### PR TITLE
1.0.11 - Use WMI event for airplane mode on serw12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-dkms (1.0.11) focal; urgency=medium
+
+  * Use WMI event for airplane mode on serw12
+
+ -- Jeremy Soller <jeremy@system76.com>  Tue, 24 Nov 2020 10:06:28 -0700
+
 system76-dkms (1.0.10) focal; urgency=medium
 
   * Add pang10

--- a/system76.c
+++ b/system76.c
@@ -63,6 +63,7 @@
 #define DRIVER_HWMON  (1 << 2)
 #define DRIVER_KB_LED (1 << 3)
 #define DRIVER_OLED   (1 << 4)
+#define DRIVER_AP_WMI (1 << 5)
 
 #define DRIVER_INPUT  (DRIVER_AP_KEY | DRIVER_OLED)
 
@@ -153,6 +154,7 @@ static void s76_wmi_notify(u32 value, void *context) {
 			s76_input_screen_wmi();
 		}
 		break;
+	case 0x85:
 	case 0xF4:
 		if (driver_flags & DRIVER_AP_KEY) {
 			s76_input_airplane_wmi();
@@ -339,7 +341,7 @@ static struct dmi_system_id s76_dmi_table[] __initdata = {
 	DMI_TABLE("oryp6", DRIVER_AP_LED | DRIVER_KB_LED),
 	DMI_TABLE("pang10", DRIVER_AP_KEY | DRIVER_KB_LED),
 	DMI_TABLE("serw11-b", DRIVER_AP_KEY | DRIVER_AP_LED | DRIVER_HWMON | DRIVER_KB_LED),
-	DMI_TABLE("serw12", DRIVER_AP_KEY | DRIVER_AP_LED | DRIVER_KB_LED),
+	DMI_TABLE("serw12", DRIVER_AP_KEY | DRIVER_AP_LED | DRIVER_AP_WMI | DRIVER_KB_LED),
 	{}
 };
 

--- a/system76_input.c
+++ b/system76_input.c
@@ -107,6 +107,8 @@ static void s76_input_screen_wmi(void) {
 }
 
 static int s76_input_open(struct input_dev *dev) {
+	int res = 0;
+
 	// Run polling thread if AP key driver is used and WMI is not supported
 	if ((driver_flags & (DRIVER_AP_KEY | DRIVER_AP_WMI)) == DRIVER_AP_KEY) {
 		s76_input_polling_task = kthread_run(
@@ -114,13 +116,14 @@ static int s76_input_open(struct input_dev *dev) {
 			NULL, "system76-polld");
 
 		if (unlikely(IS_ERR(s76_input_polling_task))) {
+			res = PTR_ERR(s76_input_polling_task);
 			s76_input_polling_task = NULL;
-			S76_ERROR("Could not create polling thread\n");
-			return PTR_ERR(s76_input_polling_task);
+			S76_ERROR("Could not create polling thread: %d\n", res);
+			return res;
 		}
 	}
 
-	return 0;
+	return res;
 }
 
 static void s76_input_close(struct input_dev *dev) {

--- a/system76_input.c
+++ b/system76_input.c
@@ -97,12 +97,6 @@ static int s76_input_polling_thread(void *data) {
 static void s76_input_airplane_wmi(void) {
 	S76_DEBUG("Airplane-Mode Hotkey pressed (WMI)\n");
 
-	if (s76_input_polling_task) {
-		S76_DEBUG("Stopping polling thread\n");
-		kthread_stop(s76_input_polling_task);
-		s76_input_polling_task = NULL;
-	}
-
 	s76_input_key(AIRPLANE_KEY);
 }
 
@@ -113,16 +107,17 @@ static void s76_input_screen_wmi(void) {
 }
 
 static int s76_input_open(struct input_dev *dev) {
-	if (driver_flags & DRIVER_AP_KEY) {
+	// Run polling thread if AP key driver is used and WMI is not supported
+	if ((driver_flags & (DRIVER_AP_KEY | DRIVER_AP_WMI)) == DRIVER_AP_KEY) {
 		s76_input_polling_task = kthread_run(
 			s76_input_polling_thread,
 			NULL, "system76-polld");
-  }
 
-	if (unlikely(IS_ERR(s76_input_polling_task))) {
-		s76_input_polling_task = NULL;
-		S76_ERROR("Could not create polling thread\n");
-		return PTR_ERR(s76_input_polling_task);
+		if (unlikely(IS_ERR(s76_input_polling_task))) {
+			s76_input_polling_task = NULL;
+			S76_ERROR("Could not create polling thread\n");
+			return PTR_ERR(s76_input_polling_task);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
This should prevent EC hangs under load with keys pressed continuously

Rebase and tag when approved