### PR TITLE
Address checkpatch issues

### DIFF
--- a/src/ap-led.c
+++ b/src/ap-led.c
@@ -1,20 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * ap_led.c
  *
  * Copyright (C) 2017 Jeremy Soller <jeremy@system76.com>
- *
- * This program is free software;  you can redistribute it and/or modify
- * it under the terms of the  GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or (at
- * your option) any later version.
- *
- * This program is  distributed in the hope that it  will be useful, but
- * WITHOUT  ANY   WARRANTY;  without   even  the  implied   warranty  of
- * MERCHANTABILITY  or FITNESS FOR  A PARTICULAR  PURPOSE.  See  the GNU
- * General Public License for more details.
- *
- * You should  have received  a copy of  the GNU General  Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 static enum led_brightness ap_led_brightness = 1;

--- a/src/ap-led.c
+++ b/src/ap-led.c
@@ -53,7 +53,7 @@ static struct led_classdev ap_led = {
 
 static ssize_t ap_led_invert_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-	return sprintf(buf, "%d\n", (int)ap_led_invert);
+	return sysfs_emit(buf, "%d\n", (int)ap_led_invert);
 }
 
 static ssize_t ap_led_invert_store(struct device *dev, struct device_attribute *attr, const char *buf, size_t size)

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -1,22 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * fan.c
  *
  * Copyright (C) 2017 Jeremy Soller <jeremy@system76.com>
  * Copyright (C) 2014-2016 Arnoud Willemsen <mail@lynthium.com>
  * Copyright (C) 2013-2015 TUXEDO Computers GmbH <tux@tuxedocomputers.com>
- *
- * This program is free software;  you can redistribute it and/or modify
- * it under the terms of the  GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or (at
- * your option) any later version.
- *
- * This program is  distributed in the hope that it  will be useful, but
- * WITHOUT  ANY   WARRANTY;  without   even  the  implied   warranty  of
- * MERCHANTABILITY  or FITNESS FOR  A PARTICULAR  PURPOSE.  See  the GNU
- * General Public License for more details.
- *
- * You should  have received  a copy of  the GNU General  Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #define EXPERIMENTAL
@@ -27,12 +15,13 @@ struct s76_hwmon {
 	struct device *dev;
 };
 
-static struct s76_hwmon *s76_hwmon = NULL;
+static struct s76_hwmon *s76_hwmon;
 
 static int s76_read_fan(int idx)
 {
 	u8 value;
 	int raw_rpm;
+
 	ec_read(0xd0 + 0x2 * idx, &value);
 	raw_rpm = value << 8;
 	ec_read(0xd1 + 0x2 * idx, &value);
@@ -45,6 +34,7 @@ static int s76_read_fan(int idx)
 static int s76_read_pwm(int idx)
 {
 	u8 value;
+
 	ec_read(0xce + idx, &value);
 	return value;
 }
@@ -52,12 +42,14 @@ static int s76_read_pwm(int idx)
 static int s76_write_pwm(int idx, u8 duty)
 {
 	u8 values[] = {idx + 1, duty};
+
 	return ec_transaction(0x99, values, sizeof(values), NULL, 0);
 }
 
 static int s76_write_pwm_auto(int idx)
 {
 	u8 values[] = {0xff, idx + 1};
+
 	return ec_transaction(0x99, values, sizeof(values), NULL, 0);
 }
 
@@ -71,6 +63,7 @@ static ssize_t s76_hwmon_show_fan_input(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	int index = to_sensor_dev_attr(attr)->index;
+
 	return sprintf(buf, "%i\n", s76_read_fan(index));
 }
 
@@ -92,6 +85,7 @@ static ssize_t s76_hwmon_show_pwm(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	int index = to_sensor_dev_attr(attr)->index;
+
 	return sprintf(buf, "%i\n", s76_read_pwm(index));
 }
 
@@ -118,6 +112,7 @@ static ssize_t s76_hwmon_show_pwm_enable(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	int index = to_sensor_dev_attr(attr)->index;
+
 	return sprintf(buf, "%i\n", pwm_enabled[index]);
 }
 
@@ -159,6 +154,7 @@ static ssize_t s76_hwmon_show_temp1_input(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	u8 value;
+
 	ec_read(0x07, &value);
 	return sprintf(buf, "%i\n", value * 1000);
 }
@@ -174,6 +170,7 @@ static ssize_t s76_hwmon_show_temp2_input(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	u8 value;
+
 	ec_read(0xcd, &value);
 	return sprintf(buf, "%i\n", value * 1000);
 }
@@ -185,22 +182,22 @@ static ssize_t s76_hwmon_show_temp2_label(struct device *dev,
 }
 #endif
 
-static SENSOR_DEVICE_ATTR(name, S_IRUGO, s76_hwmon_show_name, NULL, 0);
-static SENSOR_DEVICE_ATTR(fan1_input, S_IRUGO, s76_hwmon_show_fan_input, NULL, 0);
-static SENSOR_DEVICE_ATTR(fan1_label, S_IRUGO, s76_hwmon_show_fan_label, NULL, 0);
-static SENSOR_DEVICE_ATTR(pwm1, S_IRUGO |  S_IWUSR, s76_hwmon_show_pwm, s76_hwmon_set_pwm, 0);
-static SENSOR_DEVICE_ATTR(pwm1_enable, S_IRUGO |  S_IWUSR, s76_hwmon_show_pwm_enable, s76_hwmon_set_pwm_enable, 0);
+static SENSOR_DEVICE_ATTR(name, 0444, s76_hwmon_show_name, NULL, 0);
+static SENSOR_DEVICE_ATTR(fan1_input, 0444, s76_hwmon_show_fan_input, NULL, 0);
+static SENSOR_DEVICE_ATTR(fan1_label, 0444, s76_hwmon_show_fan_label, NULL, 0);
+static SENSOR_DEVICE_ATTR(pwm1, 0644, s76_hwmon_show_pwm, s76_hwmon_set_pwm, 0);
+static SENSOR_DEVICE_ATTR(pwm1_enable, 0644, s76_hwmon_show_pwm_enable, s76_hwmon_set_pwm_enable, 0);
 #ifdef EXPERIMENTAL
-static SENSOR_DEVICE_ATTR(fan2_input, S_IRUGO, s76_hwmon_show_fan_input, NULL, 1);
-static SENSOR_DEVICE_ATTR(fan2_label, S_IRUGO, s76_hwmon_show_fan_label, NULL, 1);
-static SENSOR_DEVICE_ATTR(pwm2, S_IRUGO |  S_IWUSR, s76_hwmon_show_pwm, s76_hwmon_set_pwm, 1);
-static SENSOR_DEVICE_ATTR(pwm2_enable, S_IRUGO |  S_IWUSR, s76_hwmon_show_pwm_enable, s76_hwmon_set_pwm_enable, 1);
+static SENSOR_DEVICE_ATTR(fan2_input, 0444, s76_hwmon_show_fan_input, NULL, 1);
+static SENSOR_DEVICE_ATTR(fan2_label, 0444, s76_hwmon_show_fan_label, NULL, 1);
+static SENSOR_DEVICE_ATTR(pwm2, 0644, s76_hwmon_show_pwm, s76_hwmon_set_pwm, 1);
+static SENSOR_DEVICE_ATTR(pwm2_enable, 0644, s76_hwmon_show_pwm_enable, s76_hwmon_set_pwm_enable, 1);
 #endif
-static SENSOR_DEVICE_ATTR(temp1_input, S_IRUGO, s76_hwmon_show_temp1_input, NULL, 0);
-static SENSOR_DEVICE_ATTR(temp1_label, S_IRUGO, s76_hwmon_show_temp1_label, NULL, 0);
+static SENSOR_DEVICE_ATTR(temp1_input, 0444, s76_hwmon_show_temp1_input, NULL, 0);
+static SENSOR_DEVICE_ATTR(temp1_label, 0444, s76_hwmon_show_temp1_label, NULL, 0);
 #ifdef EXPERIMENTAL
-static SENSOR_DEVICE_ATTR(temp2_input, S_IRUGO, s76_hwmon_show_temp2_input, NULL, 1);
-static SENSOR_DEVICE_ATTR(temp2_label, S_IRUGO, s76_hwmon_show_temp2_label, NULL, 1);
+static SENSOR_DEVICE_ATTR(temp2_input, 0444, s76_hwmon_show_temp2_input, NULL, 1);
+static SENSOR_DEVICE_ATTR(temp2_label, 0444, s76_hwmon_show_temp2_label, NULL, 1);
 #endif
 
 static struct attribute *hwmon_default_attributes[] = {

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -56,7 +56,7 @@ static int s76_write_pwm_auto(int idx)
 static ssize_t s76_hwmon_show_name(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
-	return sprintf(buf, S76_DRIVER_NAME "\n");
+	return sysfs_emit(buf, S76_DRIVER_NAME "\n");
 }
 
 static ssize_t s76_hwmon_show_fan_input(struct device *dev,
@@ -64,7 +64,7 @@ static ssize_t s76_hwmon_show_fan_input(struct device *dev,
 {
 	int index = to_sensor_dev_attr(attr)->index;
 
-	return sprintf(buf, "%i\n", s76_read_fan(index));
+	return sysfs_emit(buf, "%i\n", s76_read_fan(index));
 }
 
 static ssize_t s76_hwmon_show_fan_label(struct device *dev,
@@ -72,9 +72,9 @@ static ssize_t s76_hwmon_show_fan_label(struct device *dev,
 {
 	switch (to_sensor_dev_attr(attr)->index) {
 	case 0:
-		return sprintf(buf, "CPU fan\n");
+		return sysfs_emit(buf, "CPU fan\n");
 	case 1:
-		return sprintf(buf, "GPU fan\n");
+		return sysfs_emit(buf, "GPU fan\n");
 	}
 	return 0;
 }
@@ -86,7 +86,7 @@ static ssize_t s76_hwmon_show_pwm(struct device *dev,
 {
 	int index = to_sensor_dev_attr(attr)->index;
 
-	return sprintf(buf, "%i\n", s76_read_pwm(index));
+	return sysfs_emit(buf, "%i\n", s76_read_pwm(index));
 }
 
 static ssize_t s76_hwmon_set_pwm(struct device *dev,
@@ -113,7 +113,7 @@ static ssize_t s76_hwmon_show_pwm_enable(struct device *dev,
 {
 	int index = to_sensor_dev_attr(attr)->index;
 
-	return sprintf(buf, "%i\n", pwm_enabled[index]);
+	return sysfs_emit(buf, "%i\n", pwm_enabled[index]);
 }
 
 static ssize_t s76_hwmon_set_pwm_enable(struct device *dev,
@@ -156,13 +156,13 @@ static ssize_t s76_hwmon_show_temp1_input(struct device *dev,
 	u8 value;
 
 	ec_read(0x07, &value);
-	return sprintf(buf, "%i\n", value * 1000);
+	return sysfs_emit(buf, "%i\n", value * 1000);
 }
 
 static ssize_t s76_hwmon_show_temp1_label(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
-	return sprintf(buf, "CPU temperature\n");
+	return sysfs_emit(buf, "CPU temperature\n");
 }
 
 #ifdef EXPERIMENTAL
@@ -172,13 +172,13 @@ static ssize_t s76_hwmon_show_temp2_input(struct device *dev,
 	u8 value;
 
 	ec_read(0xcd, &value);
-	return sprintf(buf, "%i\n", value * 1000);
+	return sysfs_emit(buf, "%i\n", value * 1000);
 }
 
 static ssize_t s76_hwmon_show_temp2_label(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
-	return sprintf(buf, "GPU temperature\n");
+	return sysfs_emit(buf, "GPU temperature\n");
 }
 #endif
 

--- a/src/input.c
+++ b/src/input.c
@@ -1,22 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * input.c
  *
  * Copyright (C) 2017 Jeremy Soller <jeremy@system76.com>
  * Copyright (C) 2014-2016 Arnoud Willemsen <mail@lynthium.com>
  * Copyright (C) 2013-2015 TUXEDO Computers GmbH <tux@tuxedocomputers.com>
- *
- * This program is free software;  you can redistribute it and/or modify
- * it under the terms of the  GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or (at
- * your option) any later version.
- *
- * This program is  distributed in the hope that it  will be useful, but
- * WITHOUT  ANY   WARRANTY;  without   even  the  implied   warranty  of
- * MERCHANTABILITY  or FITNESS FOR  A PARTICULAR  PURPOSE.  See  the GNU
- * General Public License for more details.
- *
- * You should  have received  a copy of  the GNU General  Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #define AIRPLANE_KEY KEY_WLAN
@@ -51,7 +39,7 @@ static const struct kernel_param_ops param_ops_poll_freq = {
 
 static unsigned char param_poll_freq = POLL_FREQ_DEFAULT;
 #define param_check_poll_freq param_check_byte
-module_param_named(poll_freq, param_poll_freq, poll_freq, S_IRUSR);
+module_param_named(poll_freq, param_poll_freq, poll_freq, 0400);
 MODULE_PARM_DESC(poll_freq, "Set polling frequency");
 
 static struct task_struct *s76_input_polling_task;
@@ -120,7 +108,7 @@ static int s76_input_open(struct input_dev *dev)
 			s76_input_polling_thread,
 			NULL, "system76-polld");
 
-		if (unlikely(IS_ERR(s76_input_polling_task))) {
+		if (IS_ERR(s76_input_polling_task)) {
 			res = PTR_ERR(s76_input_polling_task);
 			s76_input_polling_task = NULL;
 			pr_err("Could not create polling thread: %d\n", res);
@@ -133,7 +121,7 @@ static int s76_input_open(struct input_dev *dev)
 
 static void s76_input_close(struct input_dev *dev)
 {
-	if (unlikely(IS_ERR_OR_NULL(s76_input_polling_task))) {
+	if (IS_ERR_OR_NULL(s76_input_polling_task)) {
 		return;
 	}
 

--- a/src/kb-led.c
+++ b/src/kb-led.c
@@ -167,7 +167,7 @@ static struct led_classdev kb_led = {
 
 static ssize_t kb_led_color_show(enum kb_led_region region, char *buf)
 {
-	return sprintf(buf, "%06X\n", (int)kb_led_regions[region].rgb);
+	return sysfs_emit(buf, "%06X\n", (int)kb_led_regions[region].rgb);
 }
 
 static ssize_t kb_led_color_store(enum kb_led_region region, const char *buf, size_t size)

--- a/src/kb-led.c
+++ b/src/kb-led.c
@@ -1,20 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * kb_led.c
  *
  * Copyright (C) 2017 Jeremy Soller <jeremy@system76.com>
- *
- * This program is free software;  you can redistribute it and/or modify
- * it under the terms of the  GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or (at
- * your option) any later version.
- *
- * This program is  distributed in the hope that it  will be useful, but
- * WITHOUT  ANY   WARRANTY;  without   even  the  implied   warranty  of
- * MERCHANTABILITY  or FITNESS FOR  A PARTICULAR  PURPOSE.  See  the GNU
- * General Public License for more details.
- *
- * You should  have received  a copy of  the GNU General  Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #define SET_KB_LED 0x67
@@ -31,7 +19,7 @@ enum kb_led_region {
 	KB_LED_REGION_EXTRA,
 };
 
-static enum led_brightness kb_led_brightness = 0;
+static enum led_brightness kb_led_brightness;
 
 static enum led_brightness kb_led_toggle_brightness = 72;
 
@@ -44,7 +32,7 @@ static union kb_led_color kb_led_regions[] = {
 	{ .rgb = 0xFFFFFF }
 };
 
-static int kb_led_colors_i = 0;
+static int kb_led_colors_i;
 
 static union kb_led_color kb_led_colors[] = {
 	{ .rgb = 0xFFFFFF },
@@ -63,7 +51,7 @@ static enum led_brightness kb_led_get(struct led_classdev *led_cdev)
 
 static int kb_led_set(struct led_classdev *led_cdev, enum led_brightness value)
 {
-	pr_debug("kb_led_set %d\n", (int)value);
+	pr_debug("%s %d\n", __func__, (int)value);
 
 	if (!s76_wmbb(SET_KB_LED, 0xF4000000 | value, NULL)) {
 		kb_led_brightness = value;
@@ -113,7 +101,7 @@ static void kb_led_color_set(enum kb_led_region region, union kb_led_color color
 	acpi_status status;
 	u8 *buf;
 
-	buf = (u8 *)kzalloc(8, GFP_KERNEL);
+	buf = kzalloc(8, GFP_KERNEL);
 
 	pr_debug("%s %d %06X\n", __func__, (int)region, (int)color.rgb);
 
@@ -280,21 +268,21 @@ static struct device_attribute kb_led_color_extra_dev_attr = {
 
 static void kb_led_enable(void)
 {
-	pr_debug("kb_led_enable\n");
+	pr_debug("%s\n", __func__);
 
 	s76_wmbb(SET_KB_LED, 0xE007F001, NULL);
 }
 
 static void kb_led_disable(void)
 {
-	pr_debug("kb_led_disable\n");
+	pr_debug("%s\n", __func__);
 
 	s76_wmbb(SET_KB_LED, 0xE0003001, NULL);
 }
 
 static void kb_led_suspend(void)
 {
-	pr_debug("kb_led_suspend\n");
+	pr_debug("%s\n", __func__);
 
 	// Disable keyboard backlight
 	kb_led_disable();
@@ -304,7 +292,7 @@ static void kb_led_resume(void)
 {
 	enum kb_led_region region;
 
-	pr_debug("kb_led_resume\n");
+	pr_debug("%s\n", __func__);
 
 	// Disable keyboard backlight
 	kb_led_disable();
@@ -368,7 +356,7 @@ static void __exit kb_led_exit(void)
 
 static void kb_wmi_brightness(enum led_brightness value)
 {
-	pr_debug("kb_wmi_brightness %d\n", (int)value);
+	pr_debug("%s %d\n", __func__, (int)value);
 
 	kb_led_set(&kb_led, value);
 	led_classdev_notify_brightness_hw_changed(&kb_led, value);

--- a/src/nv_hda.c
+++ b/src/nv_hda.c
@@ -1,19 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*  Based on bbswitch,
  *  Copyright (C) 2011-2013 Bumblebee Project
  *  Author: Peter Wu <lekensteyn@gmail.com>
- *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 enum {
@@ -23,7 +11,7 @@ enum {
 };
 
 static struct pci_dev *dis_dev;
-static struct pci_dev *sub_dev = NULL;
+static struct pci_dev *sub_dev;
 
 // Returns 1 if the card is disabled, 0 if enabled
 static int is_card_disabled(void)
@@ -36,7 +24,7 @@ static int is_card_disabled(void)
 
 	// read config word at 0x488
 	pci_read_config_dword(dis_dev, 0x488, &cfg_word);
-	if ((cfg_word & 0x2000000)==0x2000000) {
+	if ((cfg_word & 0x2000000) == 0x2000000) {
 		// check for subdevice. read first config dword of sub function 1
 		while ((tmp_dev = pci_get_device(PCI_ANY_ID, PCI_ANY_ID, tmp_dev)) != NULL) {
 			int pci_class = tmp_dev->class >> 8;
@@ -52,7 +40,7 @@ static int is_card_disabled(void)
 
 		if (sub_dev == NULL) {
 			pr_info("No NVIDIA audio device found, unsetting config bit.\n");
-			cfg_word|=0x2000000;
+			cfg_word |= 0x2000000;
 			pci_write_config_dword(dis_dev, 0x488, cfg_word);
 			return 1;
 		}
@@ -66,8 +54,9 @@ static int is_card_disabled(void)
 static void nv_hda_off(void)
 {
 	u32 cfg_word;
+
 	if (is_card_disabled()) {
-	return;
+		return;
 	}
 
 	// remove device
@@ -78,7 +67,7 @@ static void nv_hda_off(void)
 
 	// setting bit to turn off
 	pci_read_config_dword(dis_dev, 0x488, &cfg_word);
-	cfg_word&=0xfdffffff;
+	cfg_word &= 0xfdffffff;
 	pci_write_config_dword(dis_dev, 0x488, cfg_word);
 }
 
@@ -95,7 +84,7 @@ static void nv_hda_on(void)
 
 	// read,set bit, write config word at 0x488
 	pci_read_config_dword(dis_dev, 0x488, &cfg_word);
-	cfg_word|=0x2000000;
+	cfg_word |= 0x2000000;
 	pci_write_config_dword(dis_dev, 0x488, cfg_word);
 
 	//pci_scan_single_device

--- a/src/system76.c
+++ b/src/system76.c
@@ -1,22 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * system76.c
  *
  * Copyright (C) 2017 Jeremy Soller <jeremy@system76.com>
  * Copyright (C) 2014-2016 Arnoud Willemsen <mail@lynthium.com>
  * Copyright (C) 2013-2015 TUXEDO Computers GmbH <tux@tuxedocomputers.com>
- *
- * This program is free software;  you can redistribute it and/or modify
- * it under the terms of the  GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or (at
- * your option) any later version.
- *
- * This program is  distributed in the hope that it  will be useful, but
- * WITHOUT  ANY   WARRANTY;  without   even  the  implied   warranty  of
- * MERCHANTABILITY  or FITNESS FOR  A PARTICULAR  PURPOSE.  See  the GNU
- * General Public License for more details.
- *
- * You should  have received  a copy of  the GNU General  Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #define S76_DRIVER_NAME KBUILD_MODNAME
@@ -61,7 +49,7 @@
 
 #define DRIVER_INPUT  (DRIVER_AP_KEY | DRIVER_OLED)
 
-static uint64_t driver_flags = 0;
+static uint64_t driver_flags;
 
 struct platform_device *s76_platform_device;
 
@@ -105,7 +93,7 @@ static int s76_wmbb(u32 method_id, u32 arg, u32 *retval)
 #include "hwmon.c"
 #include "nv_hda.c"
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 static void s76_wmi_notify(union acpi_object *obj, void *context)
 #else
 static void s76_wmi_notify(u32 value, void *context)
@@ -113,7 +101,7 @@ static void s76_wmi_notify(u32 value, void *context)
 {
 	u32 event;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 	if (obj->type != ACPI_TYPE_INTEGER) {
 		pr_debug("Unexpected WMI event (%0#6x)\n", obj);
 		return;
@@ -232,7 +220,7 @@ static int __init s76_probe(struct platform_device *dev)
 	return 0;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
 static void s76_remove(struct platform_device *dev)
 #else
 static int s76_remove(struct platform_device *dev)
@@ -256,14 +244,14 @@ static int s76_remove(struct platform_device *dev)
 		ap_led_exit();
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,11,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
 #endif
 }
 
 static int s76_suspend(struct platform_device *dev, pm_message_t status)
 {
-	pr_debug("s76_suspend\n");
+	pr_debug("%s\n", __func__);
 
 	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
 		kb_led_suspend();
@@ -274,7 +262,7 @@ static int s76_suspend(struct platform_device *dev, pm_message_t status)
 
 static int s76_resume(struct platform_device *dev)
 {
-	pr_debug("s76_resume\n");
+	pr_debug("%s\n", __func__);
 
 	msleep(2000);
 
@@ -392,7 +380,7 @@ static int __init s76_init(void)
 	s76_platform_device =
 		platform_create_bundle(&s76_platform_driver, s76_probe, NULL, 0, NULL, 0);
 
-	if (unlikely(IS_ERR(s76_platform_device))) {
+	if (IS_ERR(s76_platform_device)) {
 		return PTR_ERR(s76_platform_device);
 	}
 


### PR DESCRIPTION
Address following issues reporting by checkpatch:

- Convert license blocks to SPDX ID tags
- Remove unlikely from `IS_ERR` calls
- Replace hard-coded function names with `__func__`
- Replace symbolic permissions with octals
- Add blank lines after declarations
- Do not initialize statics to 0
- Remove unneeded cast from `kzalloc`
- Add missing spacing around values

Not checkpatch, but per sysfs docs:

- Replace `sprintf` with `sysfs_emit` 