### PR TITLE
Misc cleanups

### DIFF
--- a/src/ap-led.c
+++ b/src/ap-led.c
@@ -24,17 +24,17 @@ static int ap_led_set(struct led_classdev *led_cdev, enum led_brightness value)
 		ap_led_brightness = 1;
 
 		if (ap_led_invert) {
-			byte &= ~0x40;
+			byte &= ~BIT(6);
 		} else {
-			byte |= 0x40;
+			byte |= BIT(6);
 		}
 	} else {
 		ap_led_brightness = 0;
 
 		if (ap_led_invert) {
-			byte |= 0x40;
+			byte |= BIT(6);
 		} else {
-			byte &= ~0x40;
+			byte &= ~BIT(6);
 		}
 	}
 

--- a/src/input.c
+++ b/src/input.c
@@ -7,9 +7,6 @@
  * Copyright (C) 2013-2015 TUXEDO Computers GmbH <tux@tuxedocomputers.com>
  */
 
-#define AIRPLANE_KEY KEY_WLAN
-#define SCREEN_KEY KEY_SCREENLOCK
-
 static struct input_dev *s76_input_device;
 static DEFINE_MUTEX(s76_input_report_mutex);
 
@@ -68,12 +65,12 @@ static int s76_input_polling_thread(void *data)
 		u8 byte;
 
 		ec_read(0xDB, &byte);
-		if (byte & 0x40) {
-			ec_write(0xDB, byte & ~0x40);
+		if (byte & BIT(6)) {
+			ec_write(0xDB, byte & ~BIT(6));
 
 			pr_debug("Airplane-Mode Hotkey pressed (EC)\n");
 
-			s76_input_key(AIRPLANE_KEY);
+			s76_input_key(KEY_WLAN);
 		}
 
 		msleep_interruptible(1000 / param_poll_freq);
@@ -88,14 +85,14 @@ static void s76_input_airplane_wmi(void)
 {
 	pr_debug("Airplane-Mode Hotkey pressed (WMI)\n");
 
-	s76_input_key(AIRPLANE_KEY);
+	s76_input_key(KEY_WLAN);
 }
 
 static void s76_input_screen_wmi(void)
 {
 	pr_debug("Screen Hotkey pressed (WMI)\n");
 
-	s76_input_key(SCREEN_KEY);
+	s76_input_key(KEY_SCREENLOCK);
 }
 
 static int s76_input_open(struct input_dev *dev)
@@ -142,15 +139,15 @@ static int __init s76_input_init(struct device *dev)
 	s76_input_device->name = "System76 Hotkeys";
 	s76_input_device->phys = "system76/input0";
 	s76_input_device->id.bustype = BUS_HOST;
-	set_bit(EV_KEY, s76_input_device->evbit);
+	__set_bit(EV_KEY, s76_input_device->evbit);
 
 	if (driver_flags & DRIVER_AP_KEY) {
-		set_bit(AIRPLANE_KEY, s76_input_device->keybit);
+		input_set_capability(s76_input_device, EV_KEY, KEY_WLAN);
 		ec_read(0xDB, &byte);
-		ec_write(0xDB, byte & ~0x40);
+		ec_write(0xDB, byte & ~BIT(6));
 	}
 	if (driver_flags & DRIVER_OLED) {
-		set_bit(SCREEN_KEY, s76_input_device->keybit);
+		input_set_capability(s76_input_device, EV_KEY, KEY_SCREENLOCK);
 	}
 
 	s76_input_device->open  = s76_input_open;

--- a/src/kb-led.c
+++ b/src/kb-led.c
@@ -298,7 +298,7 @@ static void kb_led_resume(void)
 	kb_led_disable();
 
 	// Reset current color
-	for (region = 0; region < sizeof(kb_led_regions)/sizeof(union kb_led_color); region++) {
+	for (region = 0; region < ARRAY_SIZE(kb_led_regions); region++) {
 		if (driver_flags & DRIVER_KB_LED_WMI)
 			kb_led_color_set_wmi(region, kb_led_regions[region]);
 		else
@@ -373,7 +373,7 @@ static void kb_wmi_dec(void)
 	int i;
 
 	if (kb_led_brightness > 0) {
-		for (i = sizeof(kb_led_levels)/sizeof(enum led_brightness); i > 0; i--) {
+		for (i = ARRAY_SIZE(kb_led_levels); i > 0; i--) {
 			if (kb_led_levels[i - 1] < kb_led_brightness) {
 				kb_wmi_brightness(kb_led_levels[i - 1]);
 				break;
@@ -389,7 +389,7 @@ static void kb_wmi_inc(void)
 	int i;
 
 	if (kb_led_brightness > 0) {
-		for (i = 0; i < sizeof(kb_led_levels)/sizeof(enum led_brightness); i++) {
+		for (i = 0; i < ARRAY_SIZE(kb_led_levels); i++) {
 			if (kb_led_levels[i] > kb_led_brightness) {
 				kb_wmi_brightness(kb_led_levels[i]);
 				break;
@@ -405,11 +405,11 @@ static void kb_wmi_color(void)
 	enum kb_led_region region;
 
 	kb_led_colors_i += 1;
-	if (kb_led_colors_i >= sizeof(kb_led_colors)/sizeof(union kb_led_color)) {
+	if (kb_led_colors_i >= ARRAY_SIZE(kb_led_colors)) {
 		kb_led_colors_i = 0;
 	}
 
-	for (region = 0; region < sizeof(kb_led_regions)/sizeof(union kb_led_color); region++) {
+	for (region = 0; region < ARRAY_SIZE(kb_led_regions); region++) {
 		if (driver_flags & DRIVER_KB_LED_WMI)
 			kb_led_color_set_wmi(region, kb_led_colors[kb_led_colors_i]);
 		else

--- a/src/system76.c
+++ b/src/system76.c
@@ -31,8 +31,8 @@
 #include <linux/version.h>
 #include <linux/workqueue.h>
 
-#define S76_EVENT_GUID  "ABBC0F6B-8EA1-11D1-00A0-C90629100000"
-#define S76_WMBB_GUID    "ABBC0F6D-8EA1-11D1-00A0-C90629100000"
+#define S76_EVENT_GUID		"ABBC0F6B-8EA1-11D1-00A0-C90629100000"
+#define S76_WMBB_GUID		"ABBC0F6D-8EA1-11D1-00A0-C90629100000"
 
 #define S76_HAS_HWMON (defined(CONFIG_HWMON) || (defined(MODULE) && defined(CONFIG_HWMON_MODULE)))
 
@@ -55,7 +55,7 @@ struct platform_device *s76_platform_device;
 
 static int s76_wmbb(u32 method_id, u32 arg, u32 *retval)
 {
-	struct acpi_buffer in  = { (acpi_size) sizeof(arg), &arg };
+	struct acpi_buffer in  = { (acpi_size)sizeof(arg), &arg };
 	struct acpi_buffer out = { ACPI_ALLOCATE_BUFFER, NULL };
 	union acpi_object *obj;
 	acpi_status status;
@@ -166,26 +166,26 @@ static void s76_wmi_notify(u32 value, void *context)
 	}
 }
 
-static int __init s76_probe(struct platform_device *dev)
+static int __init s76_probe(struct platform_device *pdev)
 {
 	int err;
 
 	if (driver_flags & DRIVER_AP_LED) {
-		err = ap_led_init(&dev->dev);
+		err = ap_led_init(&pdev->dev);
 		if (unlikely(err)) {
 			pr_err("Could not register LED device\n");
 		}
 	}
 
 	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
-		err = kb_led_init(&dev->dev);
+		err = kb_led_init(&pdev->dev);
 		if (unlikely(err)) {
 			pr_err("Could not register LED device\n");
 		}
 	}
 
 	if (driver_flags & DRIVER_INPUT) {
-		err = s76_input_init(&dev->dev);
+		err = s76_input_init(&pdev->dev);
 		if (unlikely(err)) {
 			pr_err("Could not register input device\n");
 		}
@@ -193,7 +193,7 @@ static int __init s76_probe(struct platform_device *dev)
 
 #ifdef S76_HAS_HWMON
 	if (driver_flags & DRIVER_HWMON) {
-		s76_hwmon_init(&dev->dev);
+		s76_hwmon_init(&pdev->dev);
 	}
 #endif
 
@@ -215,16 +215,16 @@ static int __init s76_probe(struct platform_device *dev)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
-static void s76_remove(struct platform_device *dev)
+static void s76_remove(struct platform_device *pdev)
 #else
-static int s76_remove(struct platform_device *dev)
+static int s76_remove(struct platform_device *pdev)
 #endif
 {
 	wmi_remove_notify_handler(S76_EVENT_GUID);
 
 	#ifdef S76_HAS_HWMON
 	if (driver_flags & DRIVER_HWMON) {
-		s76_hwmon_fini(&dev->dev);
+		s76_hwmon_fini(&pdev->dev);
 	}
 	#endif
 	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
@@ -360,12 +360,12 @@ MODULE_DEVICE_TABLE(dmi, s76_dmi_table);
 static int __init s76_init(void)
 {
 	if (!dmi_check_system(s76_dmi_table)) {
-		pr_info("Model does not utilize this driver");
+		pr_info("Model does not utilize this driver\n");
 		return -ENODEV;
 	}
 
 	if (!driver_flags) {
-		pr_info("Driver data not defined");
+		pr_info("Driver data not defined\n");
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
- Add missing newlines to logs
- Rename `platform_device` references to `pdev` for clarity
- Use `ARRAY_SIZE`
- Use non-atomic `__set_bit`
- Use `input_set_capability`
- Use `BIT` macro

No intended functional changes.