### PR TITLE
Address checkpatch issues, reduce some errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ checkpatch:
 	$(KDIR)/scripts/checkpatch.pl \
 		--no-tree \
 		--file \
+		--strict \
 		--show-types \
-		--ignore LINUX_VERSION_CODE,CONSTANT_COMPARISON \
-		src/clevo-acpi.c
+		--ignore LINUX_VERSION_CODE,CONSTANT_COMPARISON,MACRO_ARG_UNUSED,MACRO_ARG_REUSE,LONG_LINE \
+		src/clevo-acpi.c \
+		src/ap-led.c \
+		src/kb-led.c \
+		src/input.c \
+		src/hwmon.c \
+		src/system76.c

--- a/src/ap-led.c
+++ b/src/ap-led.c
@@ -23,19 +23,17 @@ static int ap_led_set(struct led_classdev *led_cdev, enum led_brightness value)
 	if (value > 0) {
 		ap_led_brightness = 1;
 
-		if (ap_led_invert) {
+		if (ap_led_invert)
 			byte &= ~BIT(6);
-		} else {
+		else
 			byte |= BIT(6);
-		}
 	} else {
 		ap_led_brightness = 0;
 
-		if (ap_led_invert) {
+		if (ap_led_invert)
 			byte |= BIT(6);
-		} else {
+		else
 			byte &= ~BIT(6);
-		}
 	}
 
 	ec_write(0xD9, byte);
@@ -63,17 +61,15 @@ static ssize_t ap_led_invert_store(struct device *dev, struct device_attribute *
 	enum led_brightness brightness;
 
 	ret = kstrtouint(buf, 0, &val);
-	if (ret) {
+	if (ret)
 		return ret;
-	}
 
 	brightness = ap_led_get(&ap_led);
 
-	if (val) {
+	if (val)
 		ap_led_invert = TRUE;
-	} else {
+	else
 		ap_led_invert = FALSE;
-	}
 
 	ap_led_set(&ap_led, brightness);
 
@@ -99,14 +95,12 @@ static int __init ap_led_init(struct device *dev)
 	int err;
 
 	err = devm_led_classdev_register(dev, &ap_led);
-	if (err < 0) {
+	if (err < 0)
 		return err;
-	}
 
 	err = device_create_file(ap_led.dev, &ap_led_invert_dev_attr);
-	if (err < 0) {
+	if (err < 0)
 		pr_err("failed to create ap_led_invert\n");
-	}
 
 	ap_led_resume();
 

--- a/src/ap-led.c
+++ b/src/ap-led.c
@@ -100,7 +100,7 @@ static int __init ap_led_init(struct device *dev)
 
 	err = device_create_file(ap_led.dev, &ap_led_invert_dev_attr);
 	if (err < 0)
-		pr_err("failed to create ap_led_invert\n");
+		pr_warn("failed to create ap_led_invert\n");
 
 	ap_led_resume();
 

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -54,7 +54,8 @@ static int s76_write_pwm_auto(int idx)
 }
 
 static ssize_t s76_hwmon_show_fan_input(struct device *dev,
-		struct device_attribute *attr, char *buf)
+					struct device_attribute *attr,
+					char *buf)
 {
 	int index = to_sensor_dev_attr(attr)->index;
 
@@ -62,7 +63,8 @@ static ssize_t s76_hwmon_show_fan_input(struct device *dev,
 }
 
 static ssize_t s76_hwmon_show_fan_label(struct device *dev,
-		struct device_attribute *attr, char *buf)
+					struct device_attribute *attr,
+					char *buf)
 {
 	switch (to_sensor_dev_attr(attr)->index) {
 	case 0:
@@ -76,7 +78,8 @@ static ssize_t s76_hwmon_show_fan_label(struct device *dev,
 static int pwm_enabled[] = {2, 2};
 
 static ssize_t s76_hwmon_show_pwm(struct device *dev,
-		struct device_attribute *attr, char *buf)
+				  struct device_attribute *attr,
+				  char *buf)
 {
 	int index = to_sensor_dev_attr(attr)->index;
 
@@ -84,7 +87,8 @@ static ssize_t s76_hwmon_show_pwm(struct device *dev,
 }
 
 static ssize_t s76_hwmon_set_pwm(struct device *dev,
-		struct device_attribute *attr, const char *buf, size_t count)
+				 struct device_attribute *attr,
+				 const char *buf, size_t count)
 {
 	u32 value;
 	int err;
@@ -103,7 +107,8 @@ static ssize_t s76_hwmon_set_pwm(struct device *dev,
 }
 
 static ssize_t s76_hwmon_show_pwm_enable(struct device *dev,
-		struct device_attribute *attr, char *buf)
+					 struct device_attribute *attr,
+					 char *buf)
 {
 	int index = to_sensor_dev_attr(attr)->index;
 
@@ -111,7 +116,8 @@ static ssize_t s76_hwmon_show_pwm_enable(struct device *dev,
 }
 
 static ssize_t s76_hwmon_set_pwm_enable(struct device *dev,
-		struct device_attribute *attr, const char *buf, size_t count)
+					struct device_attribute *attr,
+					const char *buf, size_t count)
 {
 	u32 value;
 	int err;
@@ -145,7 +151,8 @@ static ssize_t s76_hwmon_set_pwm_enable(struct device *dev,
 }
 
 static ssize_t s76_hwmon_show_temp1_input(struct device *dev,
-		struct device_attribute *attr, char *buf)
+					  struct device_attribute *attr,
+					  char *buf)
 {
 	u8 value;
 
@@ -154,14 +161,16 @@ static ssize_t s76_hwmon_show_temp1_input(struct device *dev,
 }
 
 static ssize_t s76_hwmon_show_temp1_label(struct device *dev,
-		struct device_attribute *attr, char *buf)
+					  struct device_attribute *attr,
+					  char *buf)
 {
 	return sysfs_emit(buf, "CPU temperature\n");
 }
 
 #ifdef EXPERIMENTAL
 static ssize_t s76_hwmon_show_temp2_input(struct device *dev,
-		struct device_attribute *attr, char *buf)
+					  struct device_attribute *attr,
+					  char *buf)
 {
 	u8 value;
 
@@ -170,7 +179,8 @@ static ssize_t s76_hwmon_show_temp2_input(struct device *dev,
 }
 
 static ssize_t s76_hwmon_show_temp2_label(struct device *dev,
-		struct device_attribute *attr, char *buf)
+					  struct device_attribute *attr,
+					  char *buf)
 {
 	return sysfs_emit(buf, "GPU temperature\n");
 }
@@ -219,12 +229,12 @@ static const struct attribute_group hwmon_default_group = {
 __ATTRIBUTE_GROUPS(hwmon_default);
 
 static int s76_hwmon_reboot_callback(struct notifier_block *nb,
-		unsigned long action, void *data)
+				     unsigned long action, void *data)
 {
 	s76_write_pwm_auto(0);
-	#ifdef EXPERIMENTAL
-		s76_write_pwm_auto(1);
-	#endif
+#ifdef EXPERIMENTAL
+	s76_write_pwm_auto(1);
+#endif
 	return NOTIFY_DONE;
 }
 
@@ -239,15 +249,14 @@ static int s76_hwmon_init(struct device *dev)
 		return -ENOMEM;
 
 	s76_hwmon->dev = devm_hwmon_device_register_with_groups(dev, S76_DRIVER_NAME, NULL, hwmon_default_groups);
-	if (IS_ERR(s76_hwmon->dev)) {
+	if (IS_ERR(s76_hwmon->dev))
 		return PTR_ERR(s76_hwmon->dev);
-	}
 
 	(void)devm_register_reboot_notifier(dev, &s76_hwmon_reboot_notifier);
 	s76_write_pwm_auto(0);
-	#ifdef EXPERIMENTAL
+#ifdef EXPERIMENTAL
 	s76_write_pwm_auto(1);
-	#endif
+#endif
 	return 0;
 }
 
@@ -257,9 +266,9 @@ static int s76_hwmon_fini(struct device *dev)
 		return 0;
 
 	s76_write_pwm_auto(0);
-	#ifdef EXPERIMENTAL
+#ifdef EXPERIMENTAL
 	s76_write_pwm_auto(1);
-	#endif
+#endif
 	return 0;
 }
 

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -9,7 +9,7 @@
 
 #define EXPERIMENTAL
 
-#if S76_HAS_HWMON
+#if IS_ENABLED(CONFIG_HWMON)
 
 struct s76_hwmon {
 	struct device *dev;
@@ -272,4 +272,4 @@ static int s76_hwmon_fini(struct device *dev)
 	return 0;
 }
 
-#endif // S76_HAS_HWMON
+#endif // CONFIG_HWMON

--- a/src/input.c
+++ b/src/input.c
@@ -21,13 +21,12 @@ static int param_set_poll_freq(const char *val, const struct kernel_param *kp)
 	ret = param_set_byte(val, kp);
 
 	if (!ret)
-		*((unsigned char *) kp->arg) = clamp_t(unsigned char,
-			*((unsigned char *) kp->arg),
+		*((unsigned char *)kp->arg) = clamp_t(unsigned char,
+			*((unsigned char *)kp->arg),
 			POLL_FREQ_MIN, POLL_FREQ_MAX);
 
 	return ret;
 }
-
 
 static const struct kernel_param_ops param_ops_poll_freq = {
 	.set = param_set_poll_freq,
@@ -59,7 +58,7 @@ static void s76_input_key(unsigned int code)
 static int s76_input_polling_thread(void *data)
 {
 	pr_debug("Polling thread started (PID: %i), polling at %i Hz\n",
-				current->pid, param_poll_freq);
+		 current->pid, param_poll_freq);
 
 	while (!kthread_should_stop()) {
 		u8 byte;
@@ -101,9 +100,8 @@ static int s76_input_open(struct input_dev *dev)
 
 	// Run polling thread if AP key driver is used and WMI is not supported
 	if ((driver_flags & (DRIVER_AP_KEY | DRIVER_AP_WMI)) == DRIVER_AP_KEY) {
-		s76_input_polling_task = kthread_run(
-			s76_input_polling_thread,
-			NULL, "system76-polld");
+		s76_input_polling_task = kthread_run(s76_input_polling_thread,
+						     NULL, "system76-polld");
 
 		if (IS_ERR(s76_input_polling_task)) {
 			res = PTR_ERR(s76_input_polling_task);
@@ -118,9 +116,8 @@ static int s76_input_open(struct input_dev *dev)
 
 static void s76_input_close(struct input_dev *dev)
 {
-	if (IS_ERR_OR_NULL(s76_input_polling_task)) {
+	if (IS_ERR_OR_NULL(s76_input_polling_task))
 		return;
-	}
 
 	kthread_stop(s76_input_polling_task);
 	s76_input_polling_task = NULL;
@@ -146,9 +143,9 @@ static int __init s76_input_init(struct device *dev)
 		ec_read(0xDB, &byte);
 		ec_write(0xDB, byte & ~BIT(6));
 	}
-	if (driver_flags & DRIVER_OLED) {
+
+	if (driver_flags & DRIVER_OLED)
 		input_set_capability(s76_input_device, EV_KEY, KEY_SCREENLOCK);
-	}
 
 	s76_input_device->open  = s76_input_open;
 	s76_input_device->close = s76_input_close;

--- a/src/kb-led.c
+++ b/src/kb-led.c
@@ -322,16 +322,16 @@ static int __init kb_led_init(struct device *dev)
 		return err;
 
 	if (device_create_file(kb_led.dev, &kb_led_color_left_dev_attr) != 0)
-		pr_err("failed to create kb_led_color_left\n");
+		pr_warn("failed to create kb_led_color_left\n");
 
 	if (device_create_file(kb_led.dev, &kb_led_color_center_dev_attr) != 0)
-		pr_err("failed to create kb_led_color_center\n");
+		pr_warn("failed to create kb_led_color_center\n");
 
 	if (device_create_file(kb_led.dev, &kb_led_color_right_dev_attr) != 0)
-		pr_err("failed to create kb_led_color_right\n");
+		pr_warn("failed to create kb_led_color_right\n");
 
 	if (device_create_file(kb_led.dev, &kb_led_color_extra_dev_attr) != 0)
-		pr_err("failed to create kb_led_color_extra\n");
+		pr_warn("failed to create kb_led_color_extra\n");
 
 	kb_led_resume();
 

--- a/src/kb-led.c
+++ b/src/kb-led.c
@@ -53,9 +53,8 @@ static int kb_led_set(struct led_classdev *led_cdev, enum led_brightness value)
 {
 	pr_debug("%s %d\n", __func__, (int)value);
 
-	if (!s76_wmbb(SET_KB_LED, 0xF4000000 | value, NULL)) {
+	if (!s76_wmbb(SET_KB_LED, 0xF4000000 | value, NULL))
 		kb_led_brightness = value;
-	}
 
 	return 0;
 }
@@ -87,9 +86,8 @@ static void kb_led_color_set_wmi(enum kb_led_region region, union kb_led_color c
 	cmd |= color.r <<  8;
 	cmd |= color.g <<  0;
 
-	if (!s76_wmbb(SET_KB_LED, cmd, NULL)) {
+	if (!s76_wmbb(SET_KB_LED, cmd, NULL))
 		kb_led_regions[region] = color;
-	}
 }
 
 static acpi_status clevo_ec_locate(acpi_handle handle, u32 level,
@@ -185,9 +183,8 @@ static ssize_t kb_led_color_store(enum kb_led_region region, const char *buf, si
 	union kb_led_color color;
 
 	ret = kstrtouint(buf, 16, &val);
-	if (ret) {
+	if (ret)
 		return ret;
-	}
 
 	color.rgb = (u32)val;
 	if (driver_flags & DRIVER_KB_LED_WMI)
@@ -276,22 +273,20 @@ static struct device_attribute kb_led_color_extra_dev_attr = {
 
 static void kb_led_enable(void)
 {
-	pr_debug("%s\n", __func__);
+	pr_debug("KBLED enable\n");
 
 	s76_wmbb(SET_KB_LED, 0xE007F001, NULL);
 }
 
 static void kb_led_disable(void)
 {
-	pr_debug("%s\n", __func__);
+	pr_debug("KBLED disable\n");
 
 	s76_wmbb(SET_KB_LED, 0xE0003001, NULL);
 }
 
 static void kb_led_suspend(void)
 {
-	pr_debug("%s\n", __func__);
-
 	// Disable keyboard backlight
 	kb_led_disable();
 }
@@ -299,8 +294,6 @@ static void kb_led_suspend(void)
 static void kb_led_resume(void)
 {
 	enum kb_led_region region;
-
-	pr_debug("%s\n", __func__);
 
 	// Disable keyboard backlight
 	kb_led_disable();
@@ -325,25 +318,20 @@ static int __init kb_led_init(struct device *dev)
 	int err;
 
 	err = devm_led_classdev_register(dev, &kb_led);
-	if (unlikely(err)) {
+	if (unlikely(err))
 		return err;
-	}
 
-	if (device_create_file(kb_led.dev, &kb_led_color_left_dev_attr) != 0) {
+	if (device_create_file(kb_led.dev, &kb_led_color_left_dev_attr) != 0)
 		pr_err("failed to create kb_led_color_left\n");
-	}
 
-	if (device_create_file(kb_led.dev, &kb_led_color_center_dev_attr) != 0) {
+	if (device_create_file(kb_led.dev, &kb_led_color_center_dev_attr) != 0)
 		pr_err("failed to create kb_led_color_center\n");
-	}
 
-	if (device_create_file(kb_led.dev, &kb_led_color_right_dev_attr) != 0) {
+	if (device_create_file(kb_led.dev, &kb_led_color_right_dev_attr) != 0)
 		pr_err("failed to create kb_led_color_right\n");
-	}
 
-	if (device_create_file(kb_led.dev, &kb_led_color_extra_dev_attr) != 0) {
+	if (device_create_file(kb_led.dev, &kb_led_color_extra_dev_attr) != 0)
 		pr_err("failed to create kb_led_color_extra\n");
-	}
 
 	kb_led_resume();
 
@@ -413,9 +401,8 @@ static void kb_wmi_color(void)
 	enum kb_led_region region;
 
 	kb_led_colors_i += 1;
-	if (kb_led_colors_i >= ARRAY_SIZE(kb_led_colors)) {
+	if (kb_led_colors_i >= ARRAY_SIZE(kb_led_colors))
 		kb_led_colors_i = 0;
-	}
 
 	for (region = 0; region < ARRAY_SIZE(kb_led_regions); region++) {
 		if (driver_flags & DRIVER_KB_LED_WMI)

--- a/src/system76.c
+++ b/src/system76.c
@@ -34,8 +34,6 @@
 #define S76_EVENT_GUID		"ABBC0F6B-8EA1-11D1-00A0-C90629100000"
 #define S76_WMBB_GUID		"ABBC0F6D-8EA1-11D1-00A0-C90629100000"
 
-#define S76_HAS_HWMON (defined(CONFIG_HWMON) || (defined(MODULE) && defined(CONFIG_HWMON_MODULE)))
-
 /* method IDs for S76_GET */
 #define GET_EVENT               0x01  /*   1 */
 
@@ -179,7 +177,7 @@ static int __init s76_probe(struct platform_device *pdev)
 			pr_err("Could not register input device\n");
 	}
 
-#ifdef S76_HAS_HWMON
+#if IS_ENABLED(CONFIG_HWMON)
 	if (driver_flags & DRIVER_HWMON)
 		s76_hwmon_init(&pdev->dev);
 #endif
@@ -209,7 +207,7 @@ static int s76_remove(struct platform_device *pdev)
 {
 	wmi_remove_notify_handler(S76_EVENT_GUID);
 
-#ifdef S76_HAS_HWMON
+#if IS_ENABLED(CONFIG_HWMON)
 	if (driver_flags & DRIVER_HWMON)
 		s76_hwmon_fini(&pdev->dev);
 #endif

--- a/src/system76.c
+++ b/src/system76.c
@@ -162,19 +162,19 @@ static int __init s76_probe(struct platform_device *pdev)
 	if (driver_flags & DRIVER_AP_LED) {
 		err = ap_led_init(&pdev->dev);
 		if (unlikely(err))
-			pr_err("Could not register LED device\n");
+			pr_warn("Could not register LED device\n");
 	}
 
 	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
 		err = kb_led_init(&pdev->dev);
 		if (unlikely(err))
-			pr_err("Could not register LED device\n");
+			pr_warn("Could not register LED device\n");
 	}
 
 	if (driver_flags & DRIVER_INPUT) {
 		err = s76_input_init(&pdev->dev);
 		if (unlikely(err))
-			pr_err("Could not register input device\n");
+			pr_warn("Could not register input device\n");
 	}
 
 #if IS_ENABLED(CONFIG_HWMON)

--- a/src/system76.c
+++ b/src/system76.c
@@ -39,17 +39,17 @@
 /* method IDs for S76_GET */
 #define GET_EVENT               0x01  /*   1 */
 
-#define DRIVER_AP_KEY		(1 << 0)
-#define DRIVER_AP_LED		(1 << 1)
-#define DRIVER_HWMON		(1 << 2)
-#define DRIVER_KB_LED_WMI	(1 << 3)
-#define DRIVER_OLED		(1 << 4)
-#define DRIVER_AP_WMI		(1 << 5)
-#define DRIVER_KB_LED		(1 << 6)
+#define DRIVER_AP_KEY		BIT(0)
+#define DRIVER_AP_LED		BIT(1)
+#define DRIVER_HWMON		BIT(2)
+#define DRIVER_KB_LED_WMI	BIT(3)
+#define DRIVER_OLED		BIT(4)
+#define DRIVER_AP_WMI		BIT(5)
+#define DRIVER_KB_LED		BIT(6)
 
 #define DRIVER_INPUT  (DRIVER_AP_KEY | DRIVER_OLED)
 
-static uint64_t driver_flags;
+static u64 driver_flags;
 
 struct platform_device *s76_platform_device;
 
@@ -65,22 +65,19 @@ static int s76_wmbb(u32 method_id, u32 arg, u32 *retval)
 
 	status = wmi_evaluate_method(S76_WMBB_GUID, 0, method_id, &in, &out);
 
-	if (unlikely(ACPI_FAILURE(status))) {
+	if (unlikely(ACPI_FAILURE(status)))
 		return -EIO;
-	}
 
-	obj = (union acpi_object *) out.pointer;
-	if (obj && obj->type == ACPI_TYPE_INTEGER) {
-		tmp = (u32) obj->integer.value;
-	} else {
+	obj = (union acpi_object *)out.pointer;
+	if (obj && obj->type == ACPI_TYPE_INTEGER)
+		tmp = (u32)obj->integer.value;
+	else
 		tmp = 0;
-	}
 
 	pr_debug("%0#4x  OUT: %0#6x (IN: %0#6x)\n", method_id, tmp, arg);
 
-	if (likely(retval)) {
+	if (likely(retval))
 		*retval = tmp;
-	}
 
 	kfree(obj);
 
@@ -118,19 +115,16 @@ static void s76_wmi_notify(u32 value, void *context)
 
 	switch (event) {
 	case 0x81:
-		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
+		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED))
 			kb_wmi_dec();
-		}
 		break;
 	case 0x82:
-		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
+		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED))
 			kb_wmi_inc();
-		}
 		break;
 	case 0x83:
-		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
+		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED))
 			kb_wmi_color();
-		}
 		break;
 	case 0x7b:
 		//TODO: Fn+Backspace
@@ -139,20 +133,17 @@ static void s76_wmi_notify(u32 value, void *context)
 		//TODO: Fn+ESC
 		break;
 	case 0x9F:
-		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
+		if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED))
 			kb_wmi_toggle();
-		}
 		break;
 	case 0xD7:
-		if (driver_flags & DRIVER_OLED) {
+		if (driver_flags & DRIVER_OLED)
 			s76_input_screen_wmi();
-		}
 		break;
 	case 0x85:
 	case 0xF4:
-		if (driver_flags & DRIVER_AP_KEY) {
+		if (driver_flags & DRIVER_AP_KEY)
 			s76_input_airplane_wmi();
-		}
 		break;
 	case 0xFC:
 		// Touchpad WMI (disable)
@@ -172,29 +163,25 @@ static int __init s76_probe(struct platform_device *pdev)
 
 	if (driver_flags & DRIVER_AP_LED) {
 		err = ap_led_init(&pdev->dev);
-		if (unlikely(err)) {
+		if (unlikely(err))
 			pr_err("Could not register LED device\n");
-		}
 	}
 
 	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
 		err = kb_led_init(&pdev->dev);
-		if (unlikely(err)) {
+		if (unlikely(err))
 			pr_err("Could not register LED device\n");
-		}
 	}
 
 	if (driver_flags & DRIVER_INPUT) {
 		err = s76_input_init(&pdev->dev);
-		if (unlikely(err)) {
+		if (unlikely(err))
 			pr_err("Could not register input device\n");
-		}
 	}
 
 #ifdef S76_HAS_HWMON
-	if (driver_flags & DRIVER_HWMON) {
+	if (driver_flags & DRIVER_HWMON)
 		s76_hwmon_init(&pdev->dev);
-	}
 #endif
 
 	err = wmi_install_notify_handler(S76_EVENT_GUID, s76_wmi_notify, NULL);
@@ -222,17 +209,16 @@ static int s76_remove(struct platform_device *pdev)
 {
 	wmi_remove_notify_handler(S76_EVENT_GUID);
 
-	#ifdef S76_HAS_HWMON
-	if (driver_flags & DRIVER_HWMON) {
+#ifdef S76_HAS_HWMON
+	if (driver_flags & DRIVER_HWMON)
 		s76_hwmon_fini(&pdev->dev);
-	}
-	#endif
-	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
+#endif
+
+	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED))
 		kb_led_exit();
-	}
-	if (driver_flags & DRIVER_AP_LED) {
+
+	if (driver_flags & DRIVER_AP_LED)
 		ap_led_exit();
-	}
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
@@ -241,27 +227,25 @@ static int s76_remove(struct platform_device *pdev)
 
 static int s76_suspend(struct device *dev)
 {
-	pr_debug("%s\n", __func__);
+	pr_debug("suspend\n");
 
-	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
+	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED))
 		kb_led_suspend();
-	}
 
 	return 0;
 }
 
 static int s76_resume(struct device *dev)
 {
-	pr_debug("%s\n", __func__);
+	pr_debug("resume\n");
 
 	msleep(2000);
 
-	if (driver_flags & DRIVER_AP_LED) {
+	if (driver_flags & DRIVER_AP_LED)
 		ap_led_resume();
-	}
-	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED)) {
+
+	if (driver_flags & (DRIVER_KB_LED_WMI | DRIVER_KB_LED))
 		kb_led_resume();
-	}
 
 	// Enable hotkey support
 	s76_wmbb(0x46, 0, NULL);
@@ -382,9 +366,8 @@ static int __init s76_init(void)
 	s76_platform_device =
 		platform_create_bundle(&s76_platform_driver, s76_probe, NULL, 0, NULL, 0);
 
-	if (IS_ERR(s76_platform_device)) {
+	if (IS_ERR(s76_platform_device))
 		return PTR_ERR(s76_platform_device);
-	}
 
 	return 0;
 }


### PR DESCRIPTION
Fix the following compiler warnings:

- `-Wexpansion-to-defined`

Fix the following checkpatch checks:

- `BIT_MACRO`
- `BRACES`
- `OPEN_ENDED_LINE`
- `PARENTHESIS_ALIGNMENT`
- `PREFER_KERNEL_TYPES`
- `SPACING`
- `TRACING_LOGGING`

Ignore the following checkpatch checks:

- `LONG_LINE`
- `MACRO_ARG_REUSE`
- `MACRO_ARG_UNUSED`
