### PR TITLE
keymap: Add touchpad events for AMD models

### DIFF
--- a/src/clevo-acpi.c
+++ b/src/clevo-acpi.c
@@ -58,6 +58,7 @@ static const struct key_entry clevo_keymap[] = {
 	{ KE_IGNORE, 0x83 },			// Color cycle
 	{ KE_KEY, 0x9f, { KEY_KBDILLUMTOGGLE } },
 
+	{ KE_IGNORE, 0x70 },			// Fan max off (Fn+1)
 	{ KE_IGNORE, 0x7b },			// Fn+Backspace
 	{ KE_IGNORE, 0x8f },			// Fan max on (Fn+1)
 	{ KE_IGNORE, 0x95 },			// Fn+Esc

--- a/src/clevo-acpi.c
+++ b/src/clevo-acpi.c
@@ -58,6 +58,7 @@ static const struct key_entry clevo_keymap[] = {
 	{ KE_IGNORE, 0x83 },			// Color cycle
 	{ KE_KEY, 0x9f, { KEY_KBDILLUMTOGGLE } },
 
+	{ KE_KEY, 0x5d, { KEY_F21 } },		// Touchpad disable
 	{ KE_IGNORE, 0x70 },			// Fan max off (Fn+1)
 	{ KE_IGNORE, 0x7b },			// Fn+Backspace
 	{ KE_IGNORE, 0x8f },			// Fan max on (Fn+1)


### PR DESCRIPTION
oryp14 is sending 0x5d for Fn+F1 instead of 0xfd like other models.
This likely applies to all AMD models.

Need to verify if 0x5c is seen for touchpad enable, matching the existing 0xfc.